### PR TITLE
Stop infinite error loop

### DIFF
--- a/aiothrift/protocol.py
+++ b/aiothrift/protocol.py
@@ -422,6 +422,9 @@ class TFramedTransport:
     def close(self):
         return self.__base.close()
 
+    async def wait_closed(self):
+        return self.__base.wait_closed()
+
 
 class TProtocol:
     """

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -16,6 +16,7 @@ class Server:
 
     async def __call__(self, reader, writer):
         client_addr = writer.get_extra_info('peername')
+        logger.debug(f"client {client_addr} has opened a connection")
 
         if self.framed:
             reader = TFramedTransport(reader)
@@ -24,8 +25,6 @@ class Server:
         iproto = self.protocol_cls(reader)
         oproto = self.protocol_cls(writer)
 
-        logger.debug(f"client {client_addr} has opened a connection")
-        
         try:
             while not reader.at_eof():
                 with async_timeout.timeout(self.timeout):

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -41,6 +41,7 @@ class Server:
             logger.exception("unhandled app exception")
         finally:
             writer.close()
+            await writer.wait_closed()
 
 
 async def create_server(

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -15,34 +15,32 @@ class Server:
         self.framed = framed
 
     async def __call__(self, reader, writer):
+        client_addr = writer.get_extra_info('peername')
+
         if self.framed:
             reader = TFramedTransport(reader)
             writer = TFramedTransport(writer)
 
         iproto = self.protocol_cls(reader)
         oproto = self.protocol_cls(writer)
-        
-        client_addr = writer.get_extra_info('peername')
+
         logger.debug(f"client {client_addr} has opened a connection")
         
-        while not reader.at_eof():
-            try:
+        try:
+            while not reader.at_eof():
                 with async_timeout.timeout(self.timeout):
                     await self.processor.process(iproto, oproto)
-            except ConnectionError:
-                logger.debug(f"client {client_addr} has closed the connection (connection error)")
-                writer.close()
-            except asyncio.TimeoutError:
-                logger.debug(f"timeout when processing the client request from {client_addr}")
-                writer.close()
-            except asyncio.IncompleteReadError:
-                logger.debug(f"client {client_addr} has closed the connection (incomplete read error)")
-                writer.close()
-            except Exception:
-                # app exception
-                logger.exception("unhandled app exception")
-                writer.close()
-        writer.close()
+        except ConnectionError:
+            logger.debug(f"client {client_addr} has closed the connection (ConnectionError)")
+        except asyncio.TimeoutError:
+            logger.debug(f"timeout when processing the client request from {client_addr}")
+        except asyncio.IncompleteReadError:
+            logger.debug(f"client {client_addr} has closed the connection (asyncio.IncompleteReadError)")
+        except Exception:
+            # app exception
+            logger.exception("unhandled app exception")
+        finally:
+            writer.close()
 
 
 async def create_server(


### PR DESCRIPTION
I still have to test with our "rogue" client but I believe we were getting stuck in an infinite while loop in `server.py` here, that threw an error on every loop. The errors swamped the server and caused it to crash.

I ran the existing test suite in this library and also a few one-off client tests where I opened and closed connections and everything looked okay, but I'm curious to see how this looks in our test with the client that throws all the errors...